### PR TITLE
Fix output with lots of words to match

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,8 +28,10 @@ function highlight(source, q, tpl = '<mark>$&</mark>', split = true) {
 			}
 		}
 	}
-	const regex = new RegExp(`(${spade}[0-9+])`, 'g')
-	const result = source.replace(regex, m => m.replace(m, tpl).replace(m, map[m]))
+	const result = Object.keys(map).reverse().reduce(
+		(memo, key) => memo.replace(new RegExp(key, 'g'), tpl.replace('$&', map[key])),
+		source
+	)
 	words = null
 	map = null
 	unique = null


### PR DESCRIPTION
Here is what fixed it for me. I think the problem lies in the regex of building the key names again. So it will stop with `spade1` even though it should have been `spade10` and that is why in my output I would see stuff like `the0`.